### PR TITLE
Error and StatusData  should be an array

### DIFF
--- a/src/tug/Messages/SendReport.cs
+++ b/src/tug/Messages/SendReport.cs
@@ -164,10 +164,10 @@ namespace tug.Messages
         public DscTrueFalse RebootRequested
         { get; set; }
 
-        public string Errors
+        public string[] Errors
         { get; set; }
 
-        public string StatusData
+        public string[] StatusData
         { get; set; }
 
         public AdditionalDataItem[] AdditionalData


### PR DESCRIPTION
LCM sends Errors and StatusData as an array actually so the ModelState would never be valid.